### PR TITLE
build: 2021 edition, dependency bumps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "starlink"
-version = "0.3.1"
+version = "1.0.0"
 authors = ["Elias Wilken <elias@wlkn.io>"]
-edition = "2018"
+edition = "2021"
 description = "Rust client implementation to the gRPC endpoint exposed by the SpaceX Starlink user terminal"
 documentation = "https://docs.rs/starlink"
 readme = "README.md"
@@ -21,15 +21,15 @@ exclude = [
 ]
 
 [dependencies]
-tonic = "0.8"
-prost = "0.11"
+tonic = "0.10.2"
+prost = "0.12.3"
 
 [build-dependencies]
-tonic-build = "0.8"
+tonic-build = "0.10.2"
 
 [dev-dependencies]
-async-stream = "0.3"
-tokio = { version = "1.5", features = ["rt-multi-thread"] }
+async-stream = "0.3.5"
+tokio = { version = "1.34.0", features = ["rt-multi-thread", "macros"] }
 
 [workspace]
 members = ["codegen"]

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "starlink-codegen"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Elias Wilken <elias@wlkn.io>"]
 edition = "2018"
 
 [dependencies]
-prost = "0.11"
-prost-types = "0.11"
+prost = "0.12.3"
+prost-types = "0.12.3"


### PR DESCRIPTION
Thanks for this handy crate! I used it for a lil' script to further bloat my `$PS1` with info about my Starlink connection because I love cramming it full of questionably useful information like my indoor air quality/heat pump state/satellite doohickeys.

In return, I give you this changeset of somewhat dubious utility, seeing as your crate is functionally identical without it. Take it or leave it, I guess, 'cuz it's free either way.

- Major version bump to 1.0.0 since this could theoretically break someone's CI if they are using a museumworthy toolchain

- 2018 -> 2021 because the dep updates appeared to generate code relying on `TryInto`'s prelude presence; it may be possible to fix this without an edition upgrade but I didn't investigate this on account of I need to get back to solving heinous JVM classpath issues at the job that pays for my existence

- bumped tonic & tonic-build from 0.8 -> 0.10.2

- bumped prost from 0.11 -> 0.12.3

- bumped prost-types from 0.11 -> 0.12.3

- bumped async-stream from 0.3 to 0.3.5

- bumped tokio from 1.5 to 1.34.0, added `macros` feature to fix resulting compilation errors

I tested this locally with the aforementioned script, but as that's just a `GetStatusRequest` the prudent thing to do would be to also try out your examples... but I'm lazy and don't know how your CI pipeline is set up, so, yeah. You are obviously welcome to do anything or nothing with this PR as you please.